### PR TITLE
Change default maximum file size to 10 MB in params.php

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ## 1.0.1 under development
 
-- Chg: Replace the default maximum file size for file rotation to `10` megabytes in `params.php`. (devanych)
+- Chg #29: Replace the default maximum file size for file rotation to `10` megabytes in `params.php` (devanych)
 
 ## 1.0.0 February 11, 2021
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ## 1.0.1 under development
 
-- no changes in this release.
+- Chg: Replace the default maximum file size for file rotation to `10` megabytes in `params.php`. (devanych)
 
 ## 1.0.0 February 11, 2021
 

--- a/config/params.php
+++ b/config/params.php
@@ -19,7 +19,7 @@ return [
             'fileMode' => null,
         ],
         'fileRotator' => [
-            'maxFileSize' => 10,
+            'maxFileSize' => 10240,
             'maxFiles' => 5,
             'fileMode' => null,
             'rotateByCopy' => null,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | -

Need to change the default maximum file size for file rotation to `10` megabytes in `params.php`. Now it's `10` kilobytes.