### PR TITLE
Fix #84: Preserve modification time of rotated log files in `FileRotator`

### DIFF
--- a/.github/workflows/rector-cs.yml
+++ b/.github/workflows/rector-cs.yml
@@ -1,7 +1,7 @@
 name: Rector + PHP CS Fixer
 
 on:
-  pull_request_target:
+  pull_request:
     paths:
       - 'config/**'
       - 'src/**'

--- a/.github/workflows/rector-cs.yml
+++ b/.github/workflows/rector-cs.yml
@@ -12,7 +12,7 @@ on:
       - '.php-cs-fixer.dist.php'
 
 permissions:
-  contents: read
+  contents: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -21,8 +21,5 @@ concurrency:
 jobs:
   rector:
     uses: yiisoft/actions/.github/workflows/rector-cs.yml@master
-    secrets:
-      token: ${{ secrets.YIISOFT_GITHUB_TOKEN }}
     with:
-      repository: ${{ github.event.pull_request.head.repo.full_name }}
       php: '8.0'

--- a/.github/workflows/rector-cs.yml
+++ b/.github/workflows/rector-cs.yml
@@ -12,7 +12,7 @@ on:
       - '.php-cs-fixer.dist.php'
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 3.1.1 under development
 
 - Enh #83: Explicitly import classes in "use" section (@mspirkov)
+- Bug #84: Preserve modification time of rotated log files in `FileRotator` (@terabytesoftw)
 
 ## 3.1.0 December 13, 2025
 

--- a/src/FileRotator.php
+++ b/src/FileRotator.php
@@ -132,7 +132,10 @@ final class FileRotator implements FileRotatorInterface
     private function rotate(string $rotateFile, string $newFile): void
     {
         $mTime = filemtime($rotateFile);
-        $copied = copy($rotateFile, $newFile);
+
+        if (copy($rotateFile, $newFile) === false) {
+            return;
+        }
 
         if ($this->compressRotatedFiles && !$this->isCompressed($newFile)) {
             $this->compress($newFile);
@@ -143,7 +146,7 @@ final class FileRotator implements FileRotatorInterface
             chmod($newFile, $this->fileMode);
         }
 
-        if ($copied && $mTime !== false) {
+        if ($mTime !== false) {
             touch($newFile, $mTime);
         }
     }

--- a/src/FileRotator.php
+++ b/src/FileRotator.php
@@ -132,7 +132,6 @@ final class FileRotator implements FileRotatorInterface
     private function rotate(string $rotateFile, string $newFile): void
     {
         $mTime = @filemtime($rotateFile);
-
         $copied = copy($rotateFile, $newFile);
 
         if ($this->compressRotatedFiles && !$this->isCompressed($newFile)) {

--- a/src/FileRotator.php
+++ b/src/FileRotator.php
@@ -133,9 +133,7 @@ final class FileRotator implements FileRotatorInterface
     {
         $mTime = filemtime($rotateFile);
 
-        if (copy($rotateFile, $newFile) === false) {
-            return;
-        }
+        copy($rotateFile, $newFile);
 
         if ($this->compressRotatedFiles && !$this->isCompressed($newFile)) {
             $this->compress($newFile);

--- a/src/FileRotator.php
+++ b/src/FileRotator.php
@@ -133,7 +133,7 @@ final class FileRotator implements FileRotatorInterface
     {
         $mTime = @filemtime($rotateFile);
 
-        copy($rotateFile, $newFile);
+        $copied = copy($rotateFile, $newFile);
 
         if ($this->compressRotatedFiles && !$this->isCompressed($newFile)) {
             $this->compress($newFile);
@@ -144,7 +144,7 @@ final class FileRotator implements FileRotatorInterface
             chmod($newFile, $this->fileMode);
         }
 
-        if ($mTime !== false) {
+        if ($copied && $mTime !== false) {
             touch($newFile, $mTime);
         }
     }

--- a/src/FileRotator.php
+++ b/src/FileRotator.php
@@ -13,6 +13,7 @@ use function extension_loaded;
 use function fclose;
 use function feof;
 use function file_exists;
+use function filemtime;
 use function filesize;
 use function flock;
 use function fread;
@@ -20,6 +21,7 @@ use function ftruncate;
 use function is_file;
 use function sprintf;
 use function substr;
+use function touch;
 use function unlink;
 
 use const LOCK_EX;
@@ -129,6 +131,8 @@ final class FileRotator implements FileRotatorInterface
      */
     private function rotate(string $rotateFile, string $newFile): void
     {
+        $mTime = @filemtime($rotateFile);
+
         copy($rotateFile, $newFile);
 
         if ($this->compressRotatedFiles && !$this->isCompressed($newFile)) {
@@ -138,6 +142,10 @@ final class FileRotator implements FileRotatorInterface
 
         if ($this->fileMode !== null) {
             chmod($newFile, $this->fileMode);
+        }
+
+        if ($mTime !== false) {
+            touch($newFile, $mTime);
         }
     }
 

--- a/src/FileRotator.php
+++ b/src/FileRotator.php
@@ -131,7 +131,7 @@ final class FileRotator implements FileRotatorInterface
      */
     private function rotate(string $rotateFile, string $newFile): void
     {
-        $mTime = @filemtime($rotateFile);
+        $mTime = filemtime($rotateFile);
         $copied = copy($rotateFile, $newFile);
 
         if ($this->compressRotatedFiles && !$this->isCompressed($newFile)) {

--- a/tests/FileRotatorTest.php
+++ b/tests/FileRotatorTest.php
@@ -14,10 +14,13 @@ use Yiisoft\Log\Target\File\FileTarget;
 use function clearstatcache;
 use function dirname;
 use function file_get_contents;
+use function filemtime;
 use function filesize;
 use function mkdir;
 use function range;
 use function str_repeat;
+use function time;
+use function touch;
 
 final class FileRotatorTest extends TestCase
 {
@@ -69,6 +72,34 @@ final class FileRotatorTest extends TestCase
             $this->assertSame($nonRotatedFileContent, file_get_contents($logFile . '.1'));
             $this->assertFileDoesNotExist($logFile . '.1.gz');
         }
+    }
+
+    /**
+     * @dataProvider rotateDataProvider
+     */
+    public function testRotatePreservesModificationTime(bool $compress): void
+    {
+        $rotator = new FileRotator(1, 2, null, $compress);
+        $logFile = $this->getLogFilePath();
+        $fileTarget = new FileTarget($logFile, $rotator);
+        $logger = new Logger([$fileTarget]);
+        $compressExtension = $compress ? '.gz' : '';
+
+        $logger->debug($this->generateKilobytesOfData(1));
+        $logger->flush(true);
+
+        $expectedTime = time() - 7200;
+        touch($logFile, $expectedTime);
+        clearstatcache();
+
+        $logger->debug('x');
+        $logger->flush(true);
+
+        clearstatcache();
+
+        $rotatedFile = "{$logFile}.1{$compressExtension}";
+        $this->assertFileExists($rotatedFile);
+        $this->assertSame($expectedTime, filemtime($rotatedFile));
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
